### PR TITLE
Update ecto link to ecto_sql in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Postgrex.Connection.query(pid, "SELECT * FROM point_test")
 rows: [{42, %Geo.Point{coordinates: {30.0, -90.0}, srid: 4326 }}]}}
 ```
 
-### Use with Ecto Referencing [the documentation](https://hexdocs.pm/ecto/Ecto.Adapters.Postgres.html#module-extensions):
+### Use with Ecto Referencing [the documentation](https://hexdocs.pm/ecto_sql/Ecto.Adapters.Postgres.html#module-extensions):
 
 ```elixir
 #If using with Ecto, you may want something like thing instead


### PR DESCRIPTION
Hi there! Thanks for the library!

I was just reading through the README and noticed that a link to ecto is broken due to ecto's split into ecto and ecto_sql. 

This updates the link from `ecto` to `ecto_sql`: 

https://hexdocs.pm/ecto/Ecto.Adapters.Postgres.html#module-extensions -> https://hexdocs.pm/ecto_sql/Ecto.Adapters.Postgres.html#module-extensions

Hope it helps!