### PR TITLE
Add new callback functions required by ecto 3

### DIFF
--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -86,5 +86,9 @@ if Code.ensure_loaded?(Ecto.Type) do
     end
 
     def cast(_), do: :error
+
+    def embed_as(_), do: :self
+
+    def equal?(a, b), do: a == b
   end
 end


### PR DESCRIPTION
Ecto 3 adds a couple of new functions that types should implement - this change fixes the warnings due to them not being present.