### PR TITLE
chore(Ecto.Type): Ecto 3.2+ requires callbacks for custom types. If t…

### DIFF
--- a/lib/geo_postgis/geometry.ex
+++ b/lib/geo_postgis/geometry.ex
@@ -57,7 +57,11 @@ if Code.ensure_loaded?(Ecto.Type) do
       GeometryCollection
     ]
 
-    @behaviour Ecto.Type
+    if macro_exported?(Ecto.Type, :__using__, 1) do
+      use Ecto.Type
+    else
+      @behaviour Ecto.Type
+    end
 
     def type, do: :geometry
 


### PR DESCRIPTION
…he __using__ macro is available default to newer convenience method that implements these callbacks.

@bryanjos Fixes compiler warnings related to Ecto.