### PR TITLE
Adding support for ST_FlipCoordinates

### DIFF
--- a/lib/geo_postgis.ex
+++ b/lib/geo_postgis.ex
@@ -381,4 +381,8 @@ defmodule Geo.PostGIS do
   defmacro st_bd_m_poly_from_text(wkt, srid) do
     quote do: fragment("ST_BdMPolyFromText(?, ?)", unquote(wkt), unquote(srid))
   end
+
+  defmacro st_flip_coordinates(geometryA) do 
+    quote do: fragment("ST_FlipCoordinates(?)", unquote(geometryA))
+  end
 end


### PR DESCRIPTION
Hey @bryanjos,

When creating a project I ran into an error where I had flipped the Lng/Lat into Lat/Lng. 

As noted below PostGis included ST_FlipCoordinates as of version PostGis 2.0 for just this problem (ref 1). 

I also attached the PostGis documentation (ref 2) if you wanted to check it out.

1. https://postgis.net/2013/08/18/tip_lon_lat/
2. https://postgis.net/docs/ST_FlipCoordinates.html

Thanks for supporting this library.