### PR TITLE
Include ecto as a optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule GeoPostgis.Mixfile do
       {:geo, "~> 3.3"},
       {:postgrex, "~> 0.14"},
       {:ex_doc, "~> 0.21.0", only: :dev},
+      {:ecto, "~> 3.0", optional: true},
       {:ecto_sql, "~> 3.0", optional: true, only: :test},
       {:poison, "~> 2.2 or ~> 3.0 or ~> 4.0", optional: true},
       {:jason, "~> 1.0", optional: true}


### PR DESCRIPTION
Geo.PostGIS.Geometry relies checks if Ecto.Type is present and if so compiles
the struct.  Using on nixos using mix2nix fails since the dependency is built
isolated and ecto is not included detected as a dependency.

Making it optional allows packaging tools to pickup the dependency and include in the
build output