### PR TITLE
Clarify compatibility issue with string arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Update to Geo 3.4.0
 - `Geo.PostGIS.Extension` now uses the `:binary` format instead of `:text`
 
+### Changes
+
+- Passing latitude or longitude as string instead of floats is no longer supported and raises an `argument error`
+
 ## [3.3.1] - 2019-12-13
 
 ### Fixed


### PR DESCRIPTION
We got bitten by #110 also.

The changelog is far from being clear about this change. This PR attempts to improve the situation. I'm not sure if it is better to note this in this changelog or `geo`'s or both.

Please realize that I (and probably others) consider this a breaking change. 

1) It is great that this project follows semantic versioning. In the future, consider a major bump version.

2) Consider deprecating support before breaking it

3) Consider raising a more instructive error. We currently get a `argument error` without additional detail, deep in the stack.