### PR TITLE
Adapt readme (Ecto naming change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ config :thanks, Repo,
   types: MyApp.PostgresTypes
 
 
-#Create a model
+#Create a schema
 defmodule Test do
-  use Ecto.Model
+  use Ecto.Schema
 
   schema "test" do
     field :name,           :string


### PR DESCRIPTION
I was following the readme today and noticed this typo.

As a sidenote (but something I could also add to this PR if you will), based on the same testing, I wonder if it is possible to use `Ecto.Schema` with a `field` enforced as a "point", rather than a broader `field(:geom, Geo.PostGIS.Geometry)`.