### PR TITLE
call out ecto optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule GeoPostgis.Mixfile do
       {:geo, "~> 3.5"},
       {:postgrex, ">= 0.0.0"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
+      {:ecto, "~> 3.0", optional: true},
       {:ecto_sql, "~> 3.0", optional: true, only: :test},
       {:poison, "~> 2.2 or ~> 3.0 or ~> 4.0 or ~> 5.0", optional: true},
       {:jason, "~> 1.2", optional: true}


### PR DESCRIPTION
Under elixir 1.15 code paths are pruned much more precisely when compiling deps.  When a top-level project calls out ecto and geo_postgis, elixir will see the lack of an ecto dependency here and possibly compile geo_postgis before ecto is built.

    if Code.ensure_loaded?(Ecto.Type) do
      defmodule Geo.PostGIS.Geometry do

would sometimes leave out Geo.PostGis.Geometry in elixir 1.15 and you'd get compile errors like the following in your application compile:

    module Geo.PostGIS.Geometry is not available or is yet to be defined

This change calls out this optional ecto dependency.  This can be reproduced very reliably by running:

  - mix compile
  - mix deps.compile --force geo_postgis
  - mix compile --force